### PR TITLE
Allow to work with UTF-8 characters in EPP request / response body.

### DIFF
--- a/src/main/java/com/tucows/oxrs/epprtk/rtk/transport/EPPTransportTCP.java
+++ b/src/main/java/com/tucows/oxrs/epprtk/rtk/transport/EPPTransportTCP.java
@@ -247,10 +247,10 @@ public class EPPTransportTCP extends EPPTransportBase
             }
 
             String final_xml = buf.toString();
-
-            int len = final_xml.length();
+            byte[] bytebuff = final_xml.getBytes("utf-8");
+            int len = bytebuff.length;
             writeBufferSize(writer_to_server_, len + INT_SZ);
-            writer_to_server_.write(final_xml.getBytes(), 0, len);
+            writer_to_server_.write(bytebuff, 0, len);
             writer_to_server_.flush();
         }
         catch (Exception xcp)

--- a/src/main/java/com/tucows/oxrs/epprtk/rtk/xml/EPPXMLBase.java
+++ b/src/main/java/com/tucows/oxrs/epprtk/rtk/xml/EPPXMLBase.java
@@ -458,7 +458,7 @@ public abstract class EPPXMLBase extends RTKBase
             }
         }
 
-        parser.parse(new InputSource(new ByteArrayInputStream(xml_.getBytes())));
+        parser.parse(new InputSource(new ByteArrayInputStream(xml_.getBytes("utf-8"))));
         Document document = parser.getDocument();
 
         if (!document.isSupported("Traversal", "2.0")) throw new RuntimeException("This DOM Document does not support Traversal");
@@ -783,7 +783,7 @@ public abstract class EPPXMLBase extends RTKBase
         parser.setFeature("http://apache.org/xml/features/continue-after-fatal-error", false);
         parser.setFeature("http://apache.org/xml/features/dom/include-ignorable-whitespace", false);
 
-        parser.parse(new InputSource(new ByteArrayInputStream(extension_string.getBytes())));
+        parser.parse(new InputSource(new ByteArrayInputStream(extension_string.getBytes("utf-8"))));
         Document document = parser.getDocument();
 
         if (!document.isSupported("Traversal", "2.0")) throw new RuntimeException("This DOM Document does not support Traversal");


### PR DESCRIPTION
I know that this is not the most popular library ever, but sadly I had a **_pleasure**_ to implement extension for IDN domain names using epp-rtk, pulled directly from SourceForge repo. The issue is that the code as it is there right now is capable of working with ASCII names, but not with UTF-8 ones. I had to implement extension which is sending U-Labels as one of the nodes and had wasted enough time working out where was the issue with encoding, while it ended being in the epp-rtk library itself. 

It might not be useful to anybody, and theres really small possibility that this would have been accepted on SourceForge (it's not the most active repo ever), so I'm sending the pull here as this is the next result which I had found. Plus, it never hurts to  squash some bugs:)
